### PR TITLE
Enter the Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: objective-c
+language: cpp
 os: osx
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ env:
         - ARCHITECTURE=i386
         - ARCHITECTURE=x86_64
 
+matrix:
+    fast_finish: true
+
 install:
     - brew update
     - brew install clang-format

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: cpp
 os: osx
 
-branches:
-    only:
-        - master
-
 install:
     - brew update
     - brew install clang-format

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: cpp
 os: osx
 
+env:
+    matrix:
+        - ARCHITECTURE=i386
+        - ARCHITECTURE=x86_64
+
 install:
     - brew update
     - brew install clang-format
@@ -10,20 +15,12 @@ before_script:
     - git diff --exit-code
 
 script:
-    - mkdir build build/i386 build/x86_64
+    - mkdir build
+    - cd build
 
-    - cd build/i386
-    - cmake ../.. -DCMAKE_OSX_ARCHITECTURES=i386
+    - cmake .. -DCMAKE_OSX_ARCHITECTURES=$ARCHITECTURE
     - cmake --build . --config Debug
     - cmake --build . --config Release
-    - ctest --output-on-failure --build-config Debug
-    - ctest --output-on-failure --build-config Release
-    - cd ../..
 
-    - cd build/x86_64
-    - cmake ../.. -DCMAKE_OSX_ARCHITECTURES=x86_64
-    - cmake --build . --config Debug
-    - cmake --build . --config Release
     - ctest --output-on-failure --build-config Debug
     - ctest --output-on-failure --build-config Release
-    - cd ../..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,5 @@
 clone_depth: 50
 
-branches:
-    only:
-        - master
-
 build_script:
     - mkdir build build\msvc2013_32 build\msvc2013_64
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,8 @@ environment:
     matrix:
         - CMAKE_GENERATOR: "Visual Studio 12 2013"
         - CMAKE_GENERATOR: "Visual Studio 12 2013 Win64"
+        - CMAKE_GENERATOR: "Visual Studio 14 2015"
+        - CMAKE_GENERATOR: "Visual Studio 14 2015 Win64"
 
 build_script:
     - mkdir build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,9 @@ environment:
         - CMAKE_GENERATOR: "Visual Studio 14 2015"
         - CMAKE_GENERATOR: "Visual Studio 14 2015 Win64"
 
+matrix:
+    fast_finish: true
+
 build_script:
     - mkdir build
     - cd build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,27 +1,18 @@
 clone_depth: 50
 
+environment:
+    matrix:
+        - CMAKE_GENERATOR: "Visual Studio 12 2013"
+        - CMAKE_GENERATOR: "Visual Studio 12 2013 Win64"
+
 build_script:
-    - mkdir build build\msvc2013_32 build\msvc2013_64
+    - mkdir build
+    - cd build
 
-    - cd build\msvc2013_32
-    - cmake ..\.. -G"Visual Studio 12 2013"
+    - cmake .. -G"%CMAKE_GENERATOR%"
     - cmake --build . --config Debug
     - cmake --build . --config Release
-    - cd ..\..
-
-    - cd build\msvc2013_64
-    - cmake ..\.. -G"Visual Studio 12 2013 Win64"
-    - cmake --build . --config Debug
-    - cmake --build . --config Release
-    - cd ..\..
 
 test_script:
-    - cd build\msvc2013_32
     - ctest --output-on-failure --build-config Debug
     - ctest --output-on-failure --build-config Release
-    - cd ..\..
-
-    - cd build\msvc2013_64
-    - ctest --output-on-failure --build-config Debug
-    - ctest --output-on-failure --build-config Release
-    - cd ..\..


### PR DESCRIPTION
Let's use the `matrix` feature of AppVeyor and Travis CI to split build architectures properly.
